### PR TITLE
Fix NullBooleanField

### DIFF
--- a/bootstrap_form_horizontal/templatetags/bootstrap_form_horizontal.py
+++ b/bootstrap_form_horizontal/templatetags/bootstrap_form_horizontal.py
@@ -1,11 +1,13 @@
 import datetime
 from django import template
-from django.forms.fields import BooleanField, DateTimeField
+from django.forms.fields import NullBooleanField, BooleanField, DateTimeField
 register = template.Library()
 
 @register.filter
 def is_boolean(field):
-    if isinstance(field.field, BooleanField):
+    if isinstance(field.field, NullBooleanField):
+        return False
+    elif isinstance(field.field, BooleanField):
         return True
     return False
 


### PR DESCRIPTION
Unlike regular boolean fields, `NullBooleanField` use a select dropdown.

Before:

<img width="587" alt="screen shot 2017-03-09 at 7 01 31 pm" src="https://cloud.githubusercontent.com/assets/722281/23747706/a0edd580-04fb-11e7-945a-9e9265787880.png">

After:

<img width="605" alt="screen shot 2017-03-09 at 7 02 12 pm" src="https://cloud.githubusercontent.com/assets/722281/23747709/a5a6d1ee-04fb-11e7-8a53-f55dad21928c.png">
